### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TODO:
 - ~~Field to specify the path of the file inside the SDCARD~~
     ~~Root by default until we get a file browser on FirefoxOS~~
     ~~User can pick the files(s) from a list of .vcf availables~~
-- ~~User interface (and some beatiful icons -Pablo Massa?-)~~ Thanks Pablo!
+- ~~User interface (and some beautiful icons -Pablo Massa?-)~~ Thanks Pablo!
 - ~~Tests (check a valid vCard, version 3.0 only supported right now)~~
 - ~~Refactoring (make the code a little nicer)~~
 - ~~Define a License (MIT? GNU?)~~ GLP 3.0


### PR DESCRIPTION
@elecay, I've corrected a typographical error in the documentation of the [vCardIn](https://github.com/elecay/vCardIn) project. Specifically, I've changed beatiful to beautiful. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
